### PR TITLE
:recycle: Remove unnecessary optoinal annotation

### DIFF
--- a/iOSDC2018Sample/ViewControllers/ContainerSample/ChildViewController.swift
+++ b/iOSDC2018Sample/ViewControllers/ContainerSample/ChildViewController.swift
@@ -14,7 +14,7 @@ final class ChildViewController: UIViewController {
     var tapClosure: ((String) -> Void)?
 
     @IBAction func tap(_ sender: UIButton) {
-        tapClosure!("\(referenceType!): Tapped!!")
+        tapClosure!("\(referenceType): Tapped!!")
     }
 
 }


### PR DESCRIPTION
## What
- Remove unnecessary optional annotation for referenceType property
  * `tapClosure!("\(referenceType!): Tapped!!")` -> `tapClosure!("\(referenceType): Tapped!!") `